### PR TITLE
update shadow.c to resolve pwdLastSet issue

### DIFF
--- a/nslcd/shadow.c
+++ b/nslcd/shadow.c
@@ -132,7 +132,7 @@ static long to_date(const char *dn, const char *date, const char *attr)
     strncpy(buffer, date, l);
     buffer[l] = '\0';
     errno = 0;
-    value = strtol(date, &tmp, 10);
+    value = strtol(buffer, &tmp, 10);
     if ((*date == '\0') || (*tmp != '\0'))
     {
       log_log(LOG_WARNING, "%s: %s: non-numeric", dn, attr);


### PR DESCRIPTION
we read the date into the buffer to the specified length to get it to the Unix time  (i.e. seconds) from its AD value of nanoseconds, then convert it to days for shadow. If we use date rather than buffer when converting to integer we end up trying to convert the original nanosecond value rather than the new second value.
