### PR TITLE
Use larger nslcd password buffer

### DIFF
--- a/nslcd/common.h
+++ b/nslcd/common.h
@@ -162,7 +162,7 @@ void invalidator_do(enum ldap_map_selector map);
 /* common buffer lengths */
 #define BUFLEN_NAME         256  /* user, group names and such */
 #define BUFLEN_SAFENAME     300  /* escaped name */
-#define BUFLEN_PASSWORD      64  /* passwords */
+#define BUFLEN_PASSWORD     128  /* passwords */
 #define BUFLEN_PASSWORDHASH 256  /* passwords hashes */
 #define BUFLEN_DN           256  /* distinguished names */
 #define BUFLEN_SAFEDN       300  /* escapedd dn */


### PR DESCRIPTION
I had some edge cases where 64 bytes were not enough. People are using
password managers with long generated passwords. I increased the buffer
size to 128.
