### PR TITLE
Implement disable_enumeration

### DIFF
--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -738,6 +738,23 @@
      </listitem>
     </varlistentry>
 
+    <varlistentry id="disable_enumeration">
+     <term><option>disable_enumeration</option></term>
+     <listitem>
+      <para>
+       If this option is present, functions which cause all user/group entries
+       to be loaded (getpwent(), getgrent()) from the directory will not
+       succeed in doing so. Applications that depend on being able to
+       sequentially read all users and/or groups may fail to operate correctly.
+      </para>
+      <para>
+       This can dramatically reduce ldap server load in situations where there
+       are a great number of users and/or groups.
+       This option is not recommended for most configurations.
+      </para>
+     </listitem>
+    </varlistentry>
+
     <varlistentry id="nss_getgrent_skipmembers"> <!-- since 0.9.6 -->
      <term><option>nss_getgrent_skipmembers</option> yes|no</term>
      <listitem>

--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -738,19 +738,22 @@
      </listitem>
     </varlistentry>
 
-    <varlistentry id="disable_enumeration">
-     <term><option>disable_enumeration</option></term>
+    <varlistentry id="nss_disable_enumeration">
+     <term><option>nss_disable_enumeration</option></term>
      <listitem>
       <para>
-       If this option is present, functions which cause all user/group entries
-       to be loaded (getpwent(), getgrent()) from the directory will not
-       succeed in doing so. Applications that depend on being able to
-       sequentially read all users and/or groups may fail to operate correctly.
+	If this option is present, functions which cause all user/group entries
+	to be loaded (getpwent(), getgrent()) from the directory will not
+	succeed in doing so. Applications that depend on being able to
+	sequentially read all users and/or groups may fail to operate correctly.
       </para>
       <para>
-       This can dramatically reduce ldap server load in situations where there
-       are a great number of users and/or groups.
-       This option is not recommended for most configurations.
+	This can dramatically reduce ldap server load in situations
+	where there are a great number of users and/or groups. This is
+	typically used in situations where user/program access to
+	enumerate the entire directory is undesirable, and changing the
+	behavior of the user/program is not possible.
+	This option is not recommended for most configurations.
       </para>
      </listitem>
     </varlistentry>

--- a/nslcd/cfg.c
+++ b/nslcd/cfg.c
@@ -1256,7 +1256,7 @@ static void cfg_read(const char *filename, struct ldap_config *cfg)
       cfg->threads = get_int(filename, lnr, keyword, &line);
       get_eol(filename, lnr, keyword, &line);
     }
-    else if (strcasecmp(keyword, "disable_enumeration") == 0)
+    else if (strcasecmp(keyword, "nss_disable_enumeration") == 0)
     {
       cfg->enumeration = 0;
     }

--- a/nslcd/cfg.c
+++ b/nslcd/cfg.c
@@ -1148,6 +1148,7 @@ static void cfg_defaults(struct ldap_config *cfg)
   int i;
   memset(cfg, 0, sizeof(struct ldap_config));
   cfg->threads = 5;
+  cfg->enumeration = 1;
   cfg->uidname = NULL;
   cfg->uid = NOUID;
   cfg->gid = NOGID;
@@ -1254,6 +1255,10 @@ static void cfg_read(const char *filename, struct ldap_config *cfg)
     {
       cfg->threads = get_int(filename, lnr, keyword, &line);
       get_eol(filename, lnr, keyword, &line);
+    }
+    else if (strcasecmp(keyword, "disable_enumeration") == 0)
+    {
+      cfg->enumeration = 0;
     }
     else if (strcasecmp(keyword, "uid") == 0)
     {
@@ -1629,6 +1634,7 @@ static void cfg_dump(void)
   char buffer[1024];
   int *scopep;
   log_log(LOG_DEBUG, "CFG: threads %d", nslcd_cfg->threads);
+  log_log(LOG_DEBUG, "CFG: enumeration %d", nslcd_cfg->enumeration);
   if (nslcd_cfg->uidname != NULL)
     log_log(LOG_DEBUG, "CFG: uid %s", nslcd_cfg->uidname);
   else if (nslcd_cfg->uid != NOUID)

--- a/nslcd/cfg.h
+++ b/nslcd/cfg.h
@@ -82,6 +82,7 @@ struct myldap_uri {
 
 struct ldap_config {
   int threads;    /* the number of threads to start */
+  int enumeration; /* enumeration turned on or off */
   char *uidname;  /* the user name specified in the uid option */
   uid_t uid;      /* the user id nslcd should be run as */
   gid_t gid;      /* the group id nslcd should be run as */

--- a/nslcd/nslcd.c
+++ b/nslcd/nslcd.c
@@ -390,7 +390,11 @@ static void handleconnection(int sock, MYLDAP_SESSION *session)
     case NSLCD_ACTION_GROUP_BYNAME:     (void)nslcd_group_byname(fp, session); break;
     case NSLCD_ACTION_GROUP_BYGID:      (void)nslcd_group_bygid(fp, session); break;
     case NSLCD_ACTION_GROUP_BYMEMBER:   (void)nslcd_group_bymember(fp, session); break;
-    case NSLCD_ACTION_GROUP_ALL:        (void)nslcd_group_all(fp, session); break;
+    case NSLCD_ACTION_GROUP_ALL:
+      if (nslcd_cfg->enumeration == 1) {
+	(void)nslcd_group_all(fp, session); 
+      }
+      break;
     case NSLCD_ACTION_HOST_BYNAME:      (void)nslcd_host_byname(fp, session); break;
     case NSLCD_ACTION_HOST_BYADDR:      (void)nslcd_host_byaddr(fp, session); break;
     case NSLCD_ACTION_HOST_ALL:         (void)nslcd_host_all(fp, session); break;
@@ -401,7 +405,11 @@ static void handleconnection(int sock, MYLDAP_SESSION *session)
     case NSLCD_ACTION_NETWORK_ALL:      (void)nslcd_network_all(fp, session); break;
     case NSLCD_ACTION_PASSWD_BYNAME:    (void)nslcd_passwd_byname(fp, session, uid); break;
     case NSLCD_ACTION_PASSWD_BYUID:     (void)nslcd_passwd_byuid(fp, session, uid); break;
-    case NSLCD_ACTION_PASSWD_ALL:       (void)nslcd_passwd_all(fp, session, uid); break;
+    case NSLCD_ACTION_PASSWD_ALL:       
+      if (nslcd_cfg->enumeration == 1) {
+	(void)nslcd_passwd_all(fp, session, uid);
+      }
+      break;
     case NSLCD_ACTION_PROTOCOL_BYNAME:  (void)nslcd_protocol_byname(fp, session); break;
     case NSLCD_ACTION_PROTOCOL_BYNUMBER:(void)nslcd_protocol_bynumber(fp, session); break;
     case NSLCD_ACTION_PROTOCOL_ALL:     (void)nslcd_protocol_all(fp, session); break;

--- a/nslcd/nslcd.c
+++ b/nslcd/nslcd.c
@@ -392,7 +392,7 @@ static void handleconnection(int sock, MYLDAP_SESSION *session)
     case NSLCD_ACTION_GROUP_BYMEMBER:   (void)nslcd_group_bymember(fp, session); break;
     case NSLCD_ACTION_GROUP_ALL:
       if (nslcd_cfg->enumeration == 1) {
-	(void)nslcd_group_all(fp, session); 
+	(void)nslcd_group_all(fp, session);
       }
       break;
     case NSLCD_ACTION_HOST_BYNAME:      (void)nslcd_host_byname(fp, session); break;
@@ -405,7 +405,7 @@ static void handleconnection(int sock, MYLDAP_SESSION *session)
     case NSLCD_ACTION_NETWORK_ALL:      (void)nslcd_network_all(fp, session); break;
     case NSLCD_ACTION_PASSWD_BYNAME:    (void)nslcd_passwd_byname(fp, session, uid); break;
     case NSLCD_ACTION_PASSWD_BYUID:     (void)nslcd_passwd_byuid(fp, session, uid); break;
-    case NSLCD_ACTION_PASSWD_ALL:       
+    case NSLCD_ACTION_PASSWD_ALL:
       if (nslcd_cfg->enumeration == 1) {
 	(void)nslcd_passwd_all(fp, session, uid);
       }

--- a/pynslcd/cfg.py
+++ b/pynslcd/cfg.py
@@ -83,6 +83,7 @@ nss_initgroups_ignoreusers = set()
 nss_min_uid = 0
 nss_nested_groups = False
 nss_getgrent_skipmembers = False
+nss_disable_enumeration = False
 validnames = re.compile(r'^[a-z0-9._@$][a-z0-9._@$ \\~-]{0,98}[a-z0-9._@$~-]$', re.IGNORECASE)
 pam_authz_searches = []
 pam_password_prohibit_message = None
@@ -254,6 +255,12 @@ def read(filename):
         if m:
             global deref
             deref = _deref_options[m.group('value').lower()]
+            continue
+        # nss_disable_enumeration
+        m = re.match('nss_disable_enumeration',
+                     line, re.IGNORECASE)
+        if m:
+            globals()['nss_disable_enumeration'] = True
             continue
         # nss_initgroups_ignoreusers <USER,USER>|<ALLLOCAL>
         m = re.match('nss_initgroups_ignoreusers\s+(?P<value>\S.*)',

--- a/pynslcd/group.py
+++ b/pynslcd/group.py
@@ -229,3 +229,9 @@ class GroupByMemberRequest(GroupRequest):
 class GroupAllRequest(GroupRequest):
 
     action = constants.NSLCD_ACTION_GROUP_ALL
+
+    def handle_request(self, parameters):
+        if cfg.nss_disable_enumeration:
+            return
+        else:
+            return super(GroupAllRequest, self).handle_request(parameters)

--- a/pynslcd/passwd.py
+++ b/pynslcd/passwd.py
@@ -126,6 +126,12 @@ class PasswdAllRequest(PasswdRequest):
 
     action = constants.NSLCD_ACTION_PASSWD_ALL
 
+    def handle_request(self, parameters):
+        if cfg.nss_disable_enumeration:
+            return
+        else:
+            return super(PasswdAllRequest, self).handle_request(parameters)
+
 
 def uid2entry(conn, uid):
     """Look up the user by uid and return the LDAP entry or None if the user


### PR DESCRIPTION
If this option is present, functions which cause all user/group
entries to be loaded (getpwent(), getgrent()) from the
directory will not succeed in doing so. This can dramatically
reduce ldap server load in situations where there are a great
number of users and/or groups. Applications that
depend on being able to sequentially read all users and/or
groups may fail to operate correctly. This option is not recommended
for most configurations.