### PR TITLE
Fix password expiration handling when ppolicy is used

### DIFF
--- a/nslcd/myldap.c
+++ b/nslcd/myldap.c
@@ -647,6 +647,10 @@ static int do_ppolicy_bind(MYLDAP_SESSION *session, LDAP *ld, const char *uri)
       handle_ppolicy_controls(session, ld, responsectrls);
       ldap_controls_free(responsectrls);
     }
+    if (session->policy_response == NSLCD_PAM_NEW_AUTHTOK_REQD)
+    {
+      rc = LDAP_SUCCESS;
+    }
   }
   /* return the result of the BIND operation */
   if (rc != LDAP_SUCCESS)


### PR DESCRIPTION
Following #16, I added few lines to handle password expiration (and also "change after reset") when ppolicy is used. I don't know if it is acceptable for you but it makes our system works with nss-pam-ldapd. 