### PR TITLE
Add the ability to offset UID and GID numbers.

### DIFF
--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -714,12 +714,35 @@
      </listitem>
     </varlistentry>
 
+    <varlistentry id="nss_gid_offset"> <!-- since XXX -->
+      <term><option>nss_gid_offset</option> <replaceable>NUMBER</replaceable></term>
+      <listitem>
+        <para>
+        This option specifies an offset to apply to all
+        <acronym>LDAP</acronym> group numeric ids. This can be used to
+        avoid UID collisions with local groups.
+        </para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="nss_uid_offset"> <!-- since XXX -->
+      <term><option>nss_uid_offset</option> <replaceable>NUMBER</replaceable></term>
+      <listitem>
+        <para>
+        This option specifies an offset to apply to all
+        <acronym>LDAP</acronym> user numeric ids. This can be used to
+        avoid UID collisions with local users.
+        </para>
+      </listitem>
+    </varlistentry>
+
     <varlistentry id="nss_min_uid"> <!-- since 0.8.0 -->
      <term><option>nss_min_uid</option> <replaceable>UID</replaceable></term>
      <listitem>
       <para>
        This option ensures that <acronym>LDAP</acronym> users with a numeric
-       user id lower than the specified value are ignored. Also requests for
+       user id lower than the specified value (after applying
+       <option>nss_uid_offset</option>) are ignored. Also requests for
        users with a lower user id are ignored.
       </para>
      </listitem>

--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -720,7 +720,7 @@
         <para>
         This option specifies an offset to apply to all
         <acronym>LDAP</acronym> group numeric ids. This can be used to
-        avoid UID collisions with local groups.
+        avoid GID collisions with local groups.
         </para>
       </listitem>
     </varlistentry>

--- a/nslcd/cfg.c
+++ b/nslcd/cfg.c
@@ -1239,6 +1239,8 @@ static void cfg_defaults(struct ldap_config *cfg)
   cfg->pagesize = 0;
   cfg->nss_initgroups_ignoreusers = NULL;
   cfg->nss_min_uid = 0;
+  cfg->nss_uid_offset = 0;
+  cfg->nss_gid_offset = 0;
   cfg->nss_nested_groups = 0;
   cfg->nss_getgrent_skipmembers = 0;
   cfg->nss_disable_enumeration = 0;
@@ -1575,6 +1577,16 @@ static void cfg_read(const char *filename, struct ldap_config *cfg)
       cfg->nss_min_uid = get_int(filename, lnr, keyword, &line);
       get_eol(filename, lnr, keyword, &line);
     }
+    else if (strcasecmp(keyword, "nss_uid_offset") == 0)
+    {
+      cfg->nss_uid_offset = get_int(filename, lnr, keyword, &line);
+      get_eol(filename, lnr, keyword, &line);
+    }
+    else if (strcasecmp(keyword, "nss_gid_offset") == 0)
+    {
+      cfg->nss_gid_offset = get_int(filename, lnr, keyword, &line);
+      get_eol(filename, lnr, keyword, &line);
+    }
     else if (strcasecmp(keyword, "nss_nested_groups") == 0)
     {
       cfg->nss_nested_groups = get_boolean(filename, lnr, keyword, &line);
@@ -1864,6 +1876,8 @@ static void cfg_dump(void)
     log_log(LOG_DEBUG, "CFG: nss_initgroups_ignoreusers %s", buffer);
   }
   log_log(LOG_DEBUG, "CFG: nss_min_uid %lu", (unsigned long int)nslcd_cfg->nss_min_uid);
+  log_log(LOG_DEBUG, "CFG: nss_uid_offset %lu", (unsigned long int)nslcd_cfg->nss_uid_offset);
+  log_log(LOG_DEBUG, "CFG: nss_gid_offset %lu", (unsigned long int)nslcd_cfg->nss_gid_offset);
   log_log(LOG_DEBUG, "CFG: nss_nested_groups %s", print_boolean(nslcd_cfg->nss_nested_groups));
   log_log(LOG_DEBUG, "CFG: nss_getgrent_skipmembers %s", print_boolean(nslcd_cfg->nss_getgrent_skipmembers));
   log_log(LOG_DEBUG, "CFG: nss_disable_enumeration %s", print_boolean(nslcd_cfg->nss_disable_enumeration));

--- a/nslcd/cfg.h
+++ b/nslcd/cfg.h
@@ -124,6 +124,8 @@ struct ldap_config {
   int pagesize; /* set to a greater than 0 to enable handling of paged results with the specified size */
   SET *nss_initgroups_ignoreusers;  /* the users for which no initgroups() searches should be done */
   uid_t nss_min_uid;  /* minimum uid for users retrieved from LDAP */
+  uid_t nss_uid_offset; /* offset for uids retrieved from LDAP to avoid local uid clashes */
+  gid_t nss_gid_offset; /* offset for gids retrieved from LDAP to avoid local gid clashes */
   int nss_nested_groups; /* whether to expand nested groups */
   int nss_getgrent_skipmembers;  /* whether to skip member lookups */
   int nss_disable_enumeration;  /* enumeration turned on or off */

--- a/nslcd/group.c
+++ b/nslcd/group.c
@@ -107,24 +107,25 @@ static int mkfilter_group_byname(const char *name,
    by gid, return -1 on errors */
 static int mkfilter_group_bygid(gid_t gid, char *buffer, size_t buflen)
 {
+  gid_t g = gid - nslcd_cfg->nss_gid_offset;
   /* if searching for a Windows domain SID */
   if (gidSid != NULL)
   {
     /* the given gid is a BUILTIN gid, the SID prefix is not the domain SID */
-    if ((gid >= min_builtin_rid) && (gid <= max_builtin_rid))
+    if ((g >= min_builtin_rid) && (g <= max_builtin_rid))
       return mysnprintf(buffer, buflen, "(&%s(%s=%s\\%02x\\%02x\\%02x\\%02x))",
                         group_filter, attmap_group_gidNumber, builtinSid,
-                        (int)(gid & 0xff), (int)((gid >> 8) & 0xff),
-                        (int)((gid >> 16) & 0xff), (int)((gid >> 24) & 0xff));
+                        (int)(g & 0xff), (int)((g >> 8) & 0xff),
+                        (int)((g >> 16) & 0xff), (int)((g >> 24) & 0xff));
     return mysnprintf(buffer, buflen, "(&%s(%s=%s\\%02x\\%02x\\%02x\\%02x))",
                       group_filter, attmap_group_gidNumber, gidSid,
-                      (int)(gid & 0xff), (int)((gid >> 8) & 0xff),
-                      (int)((gid >> 16) & 0xff), (int)((gid >> 24) & 0xff));
+                      (int)(g & 0xff), (int)((g >> 8) & 0xff),
+                      (int)((g >> 16) & 0xff), (int)((g >> 24) & 0xff));
   }
   else
   {
     return mysnprintf(buffer, buflen, "(&%s(%s=%lu))",
-                      group_filter, attmap_group_gidNumber, (unsigned long int)gid);
+                      group_filter, attmap_group_gidNumber, (unsigned long int)g);
   }
 }
 
@@ -376,6 +377,7 @@ static int write_group(TFILE *fp, MYLDAP_ENTRY *entry, const char *reqname,
           return 0;
         }
       }
+      gids[numgids] += nslcd_cfg->nss_gid_offset;
     }
   }
   /* get group passwd (userPassword) (use only first entry) */


### PR DESCRIPTION
This change would create a "buffer" of UIDs/GIDs for local-only users. For example, with `nss_uid_offset` set to 2000, all LDAP users would have their UIDs offset by 2000, meaning an LDAP user with UID 1000 would be translated to having UID 3000. This allows there to be local users with UIDs that will never match LDAP users in order to avoid inadvertent UID collisions. In the previous example, an LDAP user with a UID of 0 would translate to UID 2000, so any local user (in `/etc/passwd`) with UID < 2000 would be safe from potential UID collisions.

While rebasing this against master today, I realized something I hadn't taken into account previously. I wasn't sure how to handle the interaction between this PR's `nss_uid_offset` and the already-existing `nss_min_uid` attribute. In the end, I ended up applying the offset prior to any checking of `nss_min_uid`, and made a corresponding change to the documentation of the `nss_min_uid` attribute to make note of this interaction. I'm not sure this is the best way to do this, but it was the path of least resistance in getting this PR out the door.

I have not done extensive testing on this change yet. I was considering this idea for a project at work, but ended up going a different route. However, I liked the idea and still wanted to float it out there in case it was useful to others, so I implemented it in my personal time.

Let me know if there is anything that looks amiss, or any corner cases that I should address!