### PR TITLE
Add functionality for mapping login classes typically found on BSD

### DIFF
--- a/nslcd/attmap.c
+++ b/nslcd/attmap.c
@@ -176,6 +176,7 @@ const char **attmap_get_var(enum ldap_map_selector map, const char *name)
     if (strcasecmp(name, "gecos") == 0)             return &attmap_passwd_gecos;
     if (strcasecmp(name, "homeDirectory") == 0)     return &attmap_passwd_homeDirectory;
     if (strcasecmp(name, "loginShell") == 0)        return &attmap_passwd_loginShell;
+    if (strcasecmp(name, "class") == 0)             return &attmap_passwd_class;
   }
   else if (map == LM_PROTOCOLS)
   {
@@ -223,6 +224,7 @@ const char *attmap_set_mapping(const char **var, const char *value)
         (var != &attmap_passwd_gecos) &&
         (var != &attmap_passwd_homeDirectory) &&
         (var != &attmap_passwd_loginShell) &&
+        (var != &attmap_passwd_class) &&
         (var != &attmap_shadow_userPassword) &&
         (var != &attmap_shadow_shadowLastChange) &&
         (var != &attmap_shadow_shadowMin) &&

--- a/nslcd/attmap.h
+++ b/nslcd/attmap.h
@@ -51,6 +51,7 @@ extern const char *attmap_passwd_gidNumber;
 extern const char *attmap_passwd_gecos;
 extern const char *attmap_passwd_homeDirectory;
 extern const char *attmap_passwd_loginShell;
+extern const char *attmap_passwd_class;
 extern const char *attmap_protocol_cn;
 extern const char *attmap_protocol_ipProtocolNumber;
 extern const char *attmap_rpc_cn;

--- a/nslcd/cfg.c
+++ b/nslcd/cfg.c
@@ -1805,6 +1805,7 @@ static void cfg_dump(void)
   LOG_ATTMAP(LM_PASSWD, passwd, gecos);
   LOG_ATTMAP(LM_PASSWD, passwd, homeDirectory);
   LOG_ATTMAP(LM_PASSWD, passwd, loginShell);
+  LOG_ATTMAP(LM_PASSWD, passwd, class);
   LOG_ATTMAP(LM_PROTOCOLS, protocol, cn);
   LOG_ATTMAP(LM_PROTOCOLS, protocol, ipProtocolNumber);
   LOG_ATTMAP(LM_RPC, rpc, cn);

--- a/nslcd/passwd.c
+++ b/nslcd/passwd.c
@@ -63,6 +63,7 @@ const char *attmap_passwd_gidNumber     = "gidNumber";
 const char *attmap_passwd_gecos         = "\"${gecos:-$cn}\"";
 const char *attmap_passwd_homeDirectory = "homeDirectory";
 const char *attmap_passwd_loginShell    = "loginShell";
+const char *attmap_passwd_class         = "userClass";
 
 /* special properties for objectSid-based searches
    (these are already LDAP-escaped strings) */
@@ -150,6 +151,7 @@ void passwd_init(void)
   attmap_add_attributes(set, attmap_passwd_gecos);
   attmap_add_attributes(set, attmap_passwd_homeDirectory);
   attmap_add_attributes(set, attmap_passwd_loginShell);
+  attmap_add_attributes(set, attmap_passwd_class);
   passwd_attrs = set_tolist(set);
   if (passwd_attrs == NULL)
   {
@@ -429,6 +431,7 @@ static int write_passwd(TFILE *fp, MYLDAP_ENTRY *entry, const char *requser,
   char homedir[256];
   char shell[64];
   char passbuffer[BUFLEN_PASSWORDHASH];
+  char class[64];
   int i, j;
   /* get the usernames for this entry */
   usernames = myldap_get_values(entry, attmap_passwd_uid);
@@ -541,6 +544,8 @@ static int write_passwd(TFILE *fp, MYLDAP_ENTRY *entry, const char *requser,
             myldap_get_dn(entry), attmap_passwd_homeDirectory);
   /* get the shell for this entry */
   attmap_get_value(entry, attmap_passwd_loginShell, shell, sizeof(shell));
+  /* get the class for this entry */
+  attmap_get_value(entry, attmap_passwd_class, class, sizeof(class));
   /* write the entries */
   for (i = 0; usernames[i] != NULL; i++)
   {
@@ -565,6 +570,7 @@ static int write_passwd(TFILE *fp, MYLDAP_ENTRY *entry, const char *requser,
             WRITE_STRING(fp, gecos);
             WRITE_STRING(fp, homedir);
             WRITE_STRING(fp, shell);
+            WRITE_STRING(fp, class);
           }
         }
       }

--- a/nss/passwd.c
+++ b/nss/passwd.c
@@ -44,10 +44,7 @@ static nss_status_t read_passwd(TFILE *fp, struct passwd *result,
   READ_BUF_STRING(fp, result->pw_gecos);
   READ_BUF_STRING(fp, result->pw_dir);
   READ_BUF_STRING(fp, result->pw_shell);
-#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-  /* set the user access class to an empty string */
-  result->pw_class = result->pw_name + strlen(result->pw_name);
-#endif /* HAVE_STRUCT_PASSWD_PW_CLASS */
+  READ_BUF_STRING(fp, result->pw_class);
   return NSS_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
This resolves #19 

I have not tested building on other OSes that do not implement login classes, so it might be possible that we need to guard all of these changes with #ifdef HAVE_STRUCT_PASSWD_PW_CLASS

I would be happy to help fix this if so and also assist with any required documentation changes.