### PR TITLE
chsh.ldap don't works by segmentation fault

### DIFF
--- a/utils/shells.py
+++ b/utils/shells.py
@@ -28,9 +28,11 @@ import sys
 def list_shells():
     """List the shells from /etc/shells."""
     libc = ctypes.CDLL(ctypes.util.find_library("c"))
+    getusershell = libc.getusershell
+    getusershell.restype = ctypes.c_char_p
     libc.setusershell()
     while True:
-        shell = ctypes.c_char_p(libc.getusershell()).value
+        shell = getusershell()
         if not shell:
             break
         yield shell


### PR DESCRIPTION
In Debian 9.5 (nslcd-utils 0.9.7-2+deb9u1), `chsh.ldap` cannot work.

```bash
$ chsh.ldap
LDAP password for user:
Enter the new value, or press ENTER for the default
  Login Shell [/bin/bash]:
Segmentation fault
$ chsh.ldap -l
Segmentation fault
```

The reason is ctypes module cannot detect the result type of `getusershell`.

```bash
$ python
>>> import ctypes
>>> import ctypes.util
>>> libc = ctypes.CDLL(ctypes.util.find_library("c"))
>>> # Maybe, ctypes cannot find header information, so set default type (int)
... libc.getusershell.restype
<class 'ctypes.c_int'>
```

We should specify the result type explicitly.
