### PR TITLE
Add build matrix for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,12 @@ addons:
       - libldap2-dev
       - libpam0g-dev
       - libsasl2-dev
-      - python
-      - python-daemon
-      - python-ldap
-      - python-pyasn1
-      - python-pyasn1-modules
       - slapd
       - xmlto
-      - pylint
+
+install:
+  - pip install pylint python-daemon python-ldap pyasn1 pyasn1-modules
+
 script:
   # Build the package
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,31 @@
-language: c
-sudo: required
-os:
-  - linux
-compiler:
-  - gcc
+sudo: true
+language: python
+
+matrix:
+  include:
+    - os: linux
+      dist: bionic
+      python: 3.7
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-bionic-8
+            - ubuntu-toolchain-r-test
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
+    - os: linux
+      dist: bionic
+      python: 3.7
+      compiler: gcc
+    - os: linux
+      dist: xenial
+      python: 3.6
+      compiler: gcc
+    - os: linux
+      dist: xenial
+      python: 2.7
+      compiler: gcc
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,27 @@ matrix:
   include:
     - os: linux
       dist: bionic
-      python: 3.7
+      python: 3.8
       addons:
         apt:
           sources:
             - llvm-toolchain-bionic-8
             - ubuntu-toolchain-r-test
+          packages:
+            - clang-8
+            - docbook-xml
+            - docbook2x
+            - expect
+            - ldap-utils
+            - libkrb5-dev
+            - libldap2-dev
+            - libpam0g-dev
+            - libsasl2-dev
+            - slapd
+            - xmlto
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
+        - CC=clang-8
+        - CXX=clang++-8
     - os: linux
       dist: bionic
       python: 3.7


### PR DESCRIPTION
Had an issue with the `chsh.ldap` command on ArchLinux (where the default Python version is 3.8) and wanted to make sure if this project CI is running against recent C compiler and recent Python interpreter to see if it is portable.

It looks like the integration test are not working for the python library. (This could be specific to the CI environment.) The `tests/test_pynslcd_cache.py` file tries to guess the install path of the python library, and that might not be correct. Or not the same Python interpreter is called to run the tests (vs the one which was install the package). Could you help me to fix this?