### PR TITLE
Implement CRL check , configure TLS_CRLCHECK option of openldap

### DIFF
--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -655,6 +655,22 @@
       </para>
      </listitem>
     </varlistentry>
+    
+    <varlistentry id="tls_crlcheck"> <!-- since TBD -->
+     <term><option>tls_crlcheck</option> <replaceable>none|peer|all</replaceable></term>
+     <listitem>
+      <para>
+       Specifies if the Certificate Revocation List (CRL) of the CA should 
+       be used to verify if the server certicates have not been revoked.       
+       The meaning of the values is described in the
+       <citerefentry><refentrytitle>ldap.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+       manual page.
+       This requires <option>tls_cacertdir</option> parameter to be set.
+       This parameter is ignored when using GnuTLS.
+       <acronym>TLS</acronym> authentication.
+      </para>
+     </listitem>
+    </varlistentry>       
 
    </variablelist>
   </refsect2>

--- a/nslcd.conf
+++ b/nslcd.conf
@@ -66,6 +66,9 @@ base dc=example,dc=com
 #tls_cacertdir /etc/ssl/certs
 #tls_cacertfile /etc/ssl/ca.cert
 
+# Certificate Revocation List (CRL), requires TLS_CACERTDIR parameter to be set
+#tls_crlcheck all
+
 # Seed the PRNG if /dev/urandom is not provided
 #tls_randfile /var/run/egd-pool
 


### PR DESCRIPTION
The patch consists in configuring in nslcd daemon the existing CRL interface of OpenLDAP: TLS_CRLCHECK. 
This requires TLS_CACERTDIR parameter to be set, this parameter is ignored with GNUtls and Mozilla NSS.