### PR TITLE
Tolerate missing definitions for NETDB_INTERNAL and NETDB_SUCCESS

### DIFF
--- a/nss/common.h
+++ b/nss/common.h
@@ -31,6 +31,15 @@
 #include "compat/attrs.h"
 #include "compat/nss_compat.h"
 
+/* Tolerate missing definitions for NETDB_INTERNAL and NETDB_SUCCESS */
+#ifndef NETDB_INTERNAL
+#define NETDB_INTERNAL -1
+#endif
+
+#ifndef NETDB_SUCCESS
+#define NETDB_SUCCESS 0
+#endif
+
 #ifdef NSS_FLAVOUR_SOLARIS
 #include "solnss.h"
 #endif /* NSS_FLAVOUR_SOLARIS */


### PR DESCRIPTION
This fixes build issue on Alpine and potentially other non-glibc Linux distributions.

```
gcc -DHAVE_CONFIG_H -I. -I..  -I..  -fPIC -g -O2 -MT hosts.o -MD -MP -MF .deps/hosts.Tpo -c -o hosts.o hosts.c
hosts.c: In function 'read_one_hostent':
hosts.c:55:15: error: 'NETDB_INTERNAL' undeclared (first use in this function)
   55 |   *h_errnop = NETDB_INTERNAL;                                               \
      |               ^~~~~~~~~~~~~~
../common/nslcd-prot.h:220:5: note: in expansion of macro 'ERROR_OUT_BUFERROR'
  220 |     ERROR_OUT_BUFERROR(fp);                                                 \
      |     ^~~~~~~~~~~~~~~~~~
../common/nslcd-prot.h:265:3: note: in expansion of macro 'BUF_CHECK'
  265 |   BUF_CHECK(fp, tmpint32 + 1);                                              \
      |   ^~~~~~~~~
hosts.c:77:3: note: in expansion of macro 'READ_BUF_STRING'
   77 |   READ_BUF_STRING(fp, result->h_name);
      |   ^~~~~~~~~~~~~~~
hosts.c:55:15: note: each undeclared identifier is reported only once for each function it appears in
   55 |   *h_errnop = NETDB_INTERNAL;                                               \
      |               ^~~~~~~~~~~~~~
../common/nslcd-prot.h:220:5: note: in expansion of macro 'ERROR_OUT_BUFERROR'
  220 |     ERROR_OUT_BUFERROR(fp);                                                 \
      |     ^~~~~~~~~~~~~~~~~~
../common/nslcd-prot.h:265:3: note: in expansion of macro 'BUF_CHECK'
  265 |   BUF_CHECK(fp, tmpint32 + 1);                                              \
      |   ^~~~~~~~~
hosts.c:77:3: note: in expansion of macro 'READ_BUF_STRING'
   77 |   READ_BUF_STRING(fp, result->h_name);
      |   ^~~~~~~~~~~~~~~
make[2]: *** [Makefile:417: hosts.o] Error 1
make[2]: Leaving directory '/build/nss-pam-ldapd-0.9.11/nss'
make[1]: *** [Makefile:443: all-recursive] Error 1
make[1]: Leaving directory '/build/nss-pam-ldapd-0.9.11'
make: *** [Makefile:384: all] Error 2
```

Similar fix in the other project:
https://github.com/gambit/gambit/commit/490f0a7d50125478f374330f0b8754bc0aee3746

Signed-off-by: Andriy Sharandakov <ash.ashway@gmail.com>