### PR TITLE
Define NETDB_INTERNAL for musl libc

### DIFF
--- a/nss/hosts.c
+++ b/nss/hosts.c
@@ -49,6 +49,9 @@
   *h_errnop = NO_RECOVERY;                                                  \
   return NSS_STATUS_UNAVAIL;
 
+#ifndef NETDB_INTERNAL
+#define NETDB_INTERNAL -1
+#endif
 #undef ERROR_OUT_BUFERROR
 #define ERROR_OUT_BUFERROR(fp)                                              \
   *errnop = ERANGE;                                                         \

--- a/nss/networks.c
+++ b/nss/networks.c
@@ -49,6 +49,9 @@
   *h_errnop = NO_RECOVERY;                                                  \
   return NSS_STATUS_UNAVAIL;
 
+#ifndef NETDB_INTERNAL
+#define NETDB_INTERNAL -1
+#endif
 #undef ERROR_OUT_BUFERROR
 #define ERROR_OUT_BUFERROR(fp)                                              \
   *errnop = ERANGE;                                                         \


### PR DESCRIPTION
musl libc doesn't define ```NETDB_INTERNAL```. Add the definition when it's missing.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
