### PR TITLE
Add PAM parameter to avoid implicit `try_first_pass` behavior

### DIFF
--- a/man/pam_ldap.8.xml
+++ b/man/pam_ldap.8.xml
@@ -173,6 +173,17 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry id="clear_first_pass">
+    <term>
+     <option>clear_first_pass</option>
+    </term>
+    <listitem>
+     <para>
+      This causes the <acronym>PAM</acronym> module not to use the previous
+      stacked modules password and will always prompt the user.
+     </para>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </refsect1>
 

--- a/pam/pam.c
+++ b/pam/pam.c
@@ -150,6 +150,7 @@ struct pld_cfg {
   int ignore_authinfo_unavail;
   int debug;
   uid_t minimum_uid;
+  int clear_first_pass;
 };
 
 static void cfg_init(pam_handle_t *pamh, int flags,
@@ -164,6 +165,7 @@ static void cfg_init(pam_handle_t *pamh, int flags,
   cfg->ignore_authinfo_unavail = 0;
   cfg->debug = 0;
   cfg->minimum_uid = 0;
+  cfg->clear_first_pass = 0;
   /* go over arguments */
   for (i = 0; i < argc; i++)
   {
@@ -185,6 +187,8 @@ static void cfg_init(pam_handle_t *pamh, int flags,
       cfg->debug = 1;
     else if (strncmp(argv[i], "minimum_uid=", 12) == 0)
       cfg->minimum_uid = (uid_t)atoi(argv[i] + 12);
+    else if (strcmp(argv[i], "clear_first_pass") == 0)
+      cfg->clear_first_pass = 1;
     else
       pam_syslog(pamh, LOG_ERR, "unknown option: %s", argv[i]);
   }
@@ -682,6 +686,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
       pam_error(pamh, "%s", resp.msg);
     return remap_pam_rc(PAM_PERM_DENIED, &cfg);
   }
+
   /* see if we are dealing with an LDAP user first */
   rc = nslcd_request_exists(pamh, &cfg, username);
   if (rc != PAM_SUCCESS)
@@ -717,7 +722,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
       ctx->asroot = 1;
       username = "";
     }
-    else if ((ctx->oldpassword != NULL) && (*ctx->oldpassword != '\0'))
+    else if ((ctx->oldpassword != NULL) && (*ctx->oldpassword != '\0') && (!cfg.clear_first_pass))
     {
       /* we already have an old password stored (from a previous
          authentication phase) so we'll use that and don't re-check */


### PR DESCRIPTION
This change suggests new PAM parameter `clear_first_pass` that makes the module not set old authentication token that was received from previous `pam_get_authtok()` call in the authentication phase.

The use case for the parameter is to have user re-type their old password again when LDAP password policy asks for forced password change. 

1. User is prompted their password during authenticated
2. Password policy mandates password change (expired password or password has been reset)
3. User is prompted their old password again
4. User is prompted for new password

Currently step (3) cannot be executed since old password is (re)used from step (1)

Likely my request to add (3) sounds bit strange. Why ask user to type in the password two times in a row?  The motivation in my case is that we would like to have consistent behavior with another PAM module that does this. I can appreciate this use case might be uncommon and I understand if the project does not want it 🙏
 
**Background** 

Following behavior of `pam_get_authtok()` is not implemented in Linux PAM (quote from man page) 

> **try_first_pass** 
>
> Before prompting the user for their password, the module first tries the previous stacked module's password in case that satisfies this module as well.

When `PAM_OLDAUTHTOK` is in the stack  `pam_get_authtok()` should use it only if `try_first_pass` is passed - we should have the second password prompt during forced password change by not setting `try_first_pass`. But this is not the case. `try_first_pass` does nothing [linux-pam/linux-pam#357 (comment)](https://www.github.com/linux-pam/linux-pam/issues/357#issuecomment-824075325).

> The reason is that pam_get_authtok behaves like the try_first_pass is always used. Which, IMO, makes sense. But documentation should be probably improved.

The function `pam_get_authtok()` seems to be originally an [OpenPAM](https://man.freebsd.org/cgi/man.cgi?query=pam_get_authtok&sektion=3&format=html) extension where it did obey  `try_first_pass` ([link](https://protect2.fireeye.com/v1/url?k=31323334-501cfaf3-313273af-454445554331-acabe05ffbe0c610&q=1&e=c015f808-20ec-4fbc-9816-7ba83452868b&u=https%3A%2F%2Fgit.des.dev%2FOpenPAM%2FOpenPAM%2Fsrc%2Fcommit%2Fd61017e61587a577237436025f2d25e04393d64f%2Flib%2Flibpam%2Fpam_get_authtok.c%23L107-L116)).  It has been implemented in Linux PAM since 2009 but it seems `try_first_pass`  was never part of Linux PAM implementation.
