### PR TITLE
replace logging.warn with logging.warning

### DIFF
--- a/pynslcd/invalidator.py
+++ b/pynslcd/invalidator.py
@@ -58,7 +58,7 @@ def exec_invalidate(*args):
             logging.error('invalidator: %s (pid %d) killed by signal %d%s',
                           cmd, p.pid, -p.returncode, output)
     except Exception:
-        logging.warn('invalidator: %s failed', cmd, exc_info=True)
+        logging.warning('invalidator: %s failed', cmd, exc_info=True)
 
 
 def loop(fd):
@@ -109,4 +109,4 @@ def invalidate(db=None):
     try:
         os.write(signalfd, db.encode('ascii'))
     except Exception:
-        logging.warn('requesting invalidation (%s) failed', db, exc_info=True)
+        logging.warning('requesting invalidation (%s) failed', db, exc_info=True)

--- a/pynslcd/pynslcd.py
+++ b/pynslcd/pynslcd.py
@@ -245,12 +245,12 @@ def disable_nss_ldap():
         ctypes.c_int.in_dll(
             lib, '_nss_%s_enablelookups' % constants.MODULE_NAME).value = 0
     except ValueError:
-        logging.warn('probably older NSS module loaded', exc_info=True)
+        logging.warning('probably older NSS module loaded', exc_info=True)
     try:
         version_info = (ctypes.c_char_p * 2).in_dll(lib, '_nss_ldap_version')
         logging.debug('NSS_LDAP %s %s', version_info[0], version_info[1])
     except ValueError:
-        logging.warn('probably older NSS module loaded', exc_info=True)
+        logging.warning('probably older NSS module loaded', exc_info=True)
 
 
 def worker(nslcd_serversocket):


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.