### PR TITLE
Add krb5_keytab for specifying a Kerberos client keytab

### DIFF
--- a/man/nslcd.conf.5.xml
+++ b/man/nslcd.conf.5.xml
@@ -341,6 +341,16 @@
      </listitem>
     </varlistentry>
 
+    <varlistentry id="krb5_keytab"> <!-- since 0.10 -->
+     <term><option>krb5_keytab</option> <replaceable>NAME</replaceable></term>
+     <listitem>
+      <para>
+       Set the name for the GSS-API Kerberos client keytab, if supported by
+       the system Kerberos library.
+      </para>
+     </listitem>
+    </varlistentry>
+
    </variablelist>
   </refsect2>
 

--- a/pynslcd/cfg.py
+++ b/pynslcd/cfg.py
@@ -51,6 +51,8 @@ sasl_authcid = None  # FIXME: add support
 sasl_authzid = None  # FIXME: add support
 sasl_secprops = None  # FIXME: add support
 sasl_canonicalize = None  # FIXME: add support
+krb5_ccname = None  # FIXME: add support
+krb5_keytab = None  # FIXME: add support
 
 # LDAP bases to search
 bases = []
@@ -201,9 +203,10 @@ def read(filename):  # noqa: C901 (many simple branches)
         # parse options with a single value that can contain spaces
         m = re.match(
             r'(?P<keyword>binddn|rootpwmoddn|sasl_realm|sasl_authcid|'
-            r'sasl_authzid|sasl_secprops|krb5_ccname|tls_cacertdir|'
-            r'tls_cacertfile|tls_randfile|tls_ciphers|tls_cert|tls_key|'
-            r'pam_password_prohibit_message)\s+(?P<value>\S.*)',
+            r'sasl_authzid|sasl_secprops|krb5_ccname|krb5_keytab|'
+            r'tls_cacertdir|tls_cacertfile|tls_randfile|tls_ciphers|'
+            r'tls_cert|tls_key|pam_password_prohibit_message)'
+            r'\s+(?P<value>\S.*)',
             line, re.IGNORECASE)
         if m:
             globals()[m.group('keyword').lower()] = m.group('value')


### PR DESCRIPTION
Current MIT Kerberos versions support automatically obtaining client tickets from a keytab without the need for external `kinit`/`k5start`. Unfortunately nslcd prevents this by clearing its environment, and setting the keytab globally via krb5.conf is not always desirable.

It would be great if nslcd could be configured to preserve certain environment variables (also for #40), but I went for the simpler option of only setting the specific envvar.

Since the goal here was to let libkrb5 handle everything, I didn't go as far as implementing the "manual" kinit-like ticket acquisition via krb5_init_creds_set_keytab(). Not sure if that's useful.